### PR TITLE
Fixing composer install issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }
   ],
   "require": {
-    "silex/silex": "2.0.*@dev",
+    "silex/silex": "1.3.6",
     "gonzalo123/angularpostrequestserviceprovider": "1.0.*@dev",
     "doctrine/dbal": "2.6.*@dev"
   },


### PR DESCRIPTION
 Problem 1
    - Conclusion: don't install silex/silex v2.0.4
    - Conclusion: don't install silex/silex v2.0.3
    - Installation request for gonzalo123/angularpostrequestserviceprovider 1.0.*@dev -> satisfiable by gonzalo123/angularpostrequestserviceprovider[1.0.x-dev].
    - Conclusion: don't install silex/silex v2.0.2
    - Conclusion: don't install silex/silex v2.0.1
    - gonzalo123/angularpostrequestserviceprovider 1.0.x-dev requires silex/silex >=v1.1.2, <2.0 -> satisfiable by silex/silex[1.1.x-dev, 1.2.x-dev, 1.3.x-dev].
    - Can only install one of: silex/silex[v2.0.0, 1.1.x-dev].
    - Can only install one of: silex/silex[v2.0.0, 1.2.x-dev].
    - Can only install one of: silex/silex[v2.0.0, 1.3.x-dev].
    - Installation request for silex/silex 2.0.*@dev -> satisfiable by silex/silex[v2.0.0, v2.0.1, v2.0.2, v2.0.3, v2.0.4].